### PR TITLE
Updates quote-string regex in json2scssMap.js

### DIFF
--- a/src/json2scssMap.js
+++ b/src/json2scssMap.js
@@ -55,9 +55,9 @@ function json2scssMap(value) {
 
 const indentsToSpaces = (indentCount) =>  Array(indentCount + 1).join('  ');
 const quoteString = (value) => {
-  const regx = /(px|rem|em|%|vw|vh|ch)/g;
+  const regexValue = /(px|rem|em|%|vw|vh|ch|))/g;
   const regexColor = /(#([\da-f]{3}){1,2}|(rgb|hsl)a\((\d{1,3}%?,\s?){3}(1|0?\.\d+)\)|(rgb|hsl)\(\d{1,3}%?(,\s?\d{1,3}%?){2}\))/ig;
-  if (regexColor.test(value) || regx.test(value)) {
+  if (regexValue.test(value) || regexColor.test(value)) {
     return value;
   }
   return "\"" + value + "\"";

--- a/src/json2scssMap.js
+++ b/src/json2scssMap.js
@@ -55,7 +55,7 @@ function json2scssMap(value) {
 
 const indentsToSpaces = (indentCount) =>  Array(indentCount + 1).join('  ');
 const quoteString = (value) => {
-  const regexValue = /(px|rem|em|%|vw|vh|ch|))/g;
+  const regexValue = /(px|rem|em|%|vw|vh|ch|\))/g;
   const regexColor = /(#([\da-f]{3}){1,2}|(rgb|hsl)a\((\d{1,3}%?,\s?){3}(1|0?\.\d+)\)|(rgb|hsl)\(\d{1,3}%?(,\s?\d{1,3}%?){2}\))/ig;
   if (regexValue.test(value) || regexColor.test(value)) {
     return value;

--- a/src/json2scssMap.js
+++ b/src/json2scssMap.js
@@ -55,7 +55,7 @@ function json2scssMap(value) {
 
 const indentsToSpaces = (indentCount) =>  Array(indentCount + 1).join('  ');
 const quoteString = (value) => {
-  const regexValue = /(px|rem|em|%|vw|vh|ch|\))/g;
+  const regexValue = /(px|rem|em|%|vw|vh|ch|var\(-)/g;
   const regexColor = /(#([\da-f]{3}){1,2}|(rgb|hsl)a\((\d{1,3}%?,\s?){3}(1|0?\.\d+)\)|(rgb|hsl)\(\d{1,3}%?(,\s?\d{1,3}%?){2}\))/ig;
   if (regexValue.test(value) || regexColor.test(value)) {
     return value;

--- a/src/json2scssMap.js
+++ b/src/json2scssMap.js
@@ -55,7 +55,7 @@ function json2scssMap(value) {
 
 const indentsToSpaces = (indentCount) =>  Array(indentCount + 1).join('  ');
 const quoteString = (value) => {
-  const regexValue = /(px|rem|em|%|vw|vh|ch|var\(-)/g;
+  const regexValue = /(px|rem|em|%|vw|vh|ch|var\(--)/g;
   const regexColor = /(#([\da-f]{3}){1,2}|(rgb|hsl)a\((\d{1,3}%?,\s?){3}(1|0?\.\d+)\)|(rgb|hsl)\(\d{1,3}%?(,\s?\d{1,3}%?){2}\))/ig;
   if (regexValue.test(value) || regexColor.test(value)) {
     return value;


### PR DESCRIPTION
Thanks for porting this lib!

Adding ")" to the regex value check. If a value contains parentheses, quote strings are not needed.

Came across this snag when trying to use css-variables from the generated scss map. css-variables will not work if stringified, e.g.:

.el {
...
background-color: "var(--color-bg-light)";
...
}