### PR TITLE
Fix bad recursion when parsing arrays.

### DIFF
--- a/src/__tests__/json2scssMap-test.js
+++ b/src/__tests__/json2scssMap-test.js
@@ -14,9 +14,10 @@ var foo = new Foo();
 describe('JSON to SCSS Map', function() {
   it('should handle strings', function() {
     expect(json2scssMap('foo')).to.equal('"foo"');
+    expect(json2scssMap('item')).to.equal('"item"');
     expect(json2scssMap('12px')).to.equal('12px');
     expect(json2scssMap('14ch')).to.equal('14ch');
-    expect(json2scssMap('2rem')).to.equal('2rem');
+    expect(json2scssMap('2.4rem')).to.equal('2.4rem');
     expect(json2scssMap('#232323')).to.equal('#232323');
     expect(json2scssMap('rgba(255,34,21, .6)')).to.equal('rgba(255,34,21, .6)');
   });

--- a/src/__tests__/json2scssMap-test.js
+++ b/src/__tests__/json2scssMap-test.js
@@ -66,4 +66,9 @@ describe('JSON to SCSS Map', function() {
 
     expect(json2scssMap(obj)).to.equal('((\n  "foo": "bar"\n), (\n  "baz": 4\n))');
   });
+  it('should correctly convert a single-item list', function() {
+    var obj = [ 'only item' ];
+
+    expect(json2scssMap(obj)).to.equal('("only item",)');
+  });
 });

--- a/src/__tests__/json2scssMap-test.js
+++ b/src/__tests__/json2scssMap-test.js
@@ -54,8 +54,8 @@ describe('JSON to SCSS Map', function() {
       },
     };
 
-    expect(json2scssMap(obj)).to.equal('(\n  "foo": "bar",\n  "bar": (\n    "baz": "foo"\n  )\n)')
-  })
+    expect(json2scssMap(obj)).to.equal('(\n  "foo": "bar",\n  "bar": (\n    "baz": "foo"\n  )\n)');
+  });
 
   it('should convert an array of objects to a list of maps', function() {
     var obj = [

--- a/src/__tests__/json2scssMap-test.js
+++ b/src/__tests__/json2scssMap-test.js
@@ -56,4 +56,13 @@ describe('JSON to SCSS Map', function() {
 
     expect(json2scssMap(obj)).to.equal('(\n  "foo": "bar",\n  "bar": (\n    "baz": "foo"\n  )\n)')
   })
+
+  it('should convert an array of objects to a list of maps', function() {
+    var obj = [
+      { foo: 'bar' },
+      { baz: 4 }
+    ];
+
+    expect(json2scssMap(obj)).to.equal('((\n  "foo": "bar"\n), (\n  "baz": 4\n))');
+  });
 });

--- a/src/json2scssMap.js
+++ b/src/json2scssMap.js
@@ -41,7 +41,11 @@ function json2scssMap(value) {
           let sassVals = value.map(v => {
               if(!isUndefined(v)) return _json2scssMap(v, indentLevel)
             })
-          return '(' + sassVals.join(', ') + ')';
+          if (sassVals.length > 1)
+            sassVals = sassVals.join(', ');
+          else
+            sassVals = sassVals[0] + ',';
+          return '(' + sassVals + ')';
         }
         else if (isNull(value)) return 'null';
         else return value.toString();

--- a/src/json2scssMap.js
+++ b/src/json2scssMap.js
@@ -38,7 +38,7 @@ function json2scssMap(value) {
           return result;
         }
         else if (isArray(value)) {
-          let sassVals = value.filter(v => {
+          let sassVals = value.map(v => {
               if(!isUndefined(v)) return _json2scssMap(v, indentLevel)
             })
           return '(' + sassVals.join(', ') + ')';

--- a/src/json2scssMap.js
+++ b/src/json2scssMap.js
@@ -59,7 +59,7 @@ function json2scssMap(value) {
 
 const indentsToSpaces = (indentCount) =>  Array(indentCount + 1).join('  ');
 const quoteString = (value) => {
-  const regx = /(px|rem|em|%|vw|vh|ch)/g;
+  const regx = /^[\d.]*\d(px|rem|em|%|vw|vh|ch)$/g;
   const regexColor = /(#([\da-f]{3}){1,2}|(rgb|hsl)a\((\d{1,3}%?,\s?){3}(1|0?\.\d+)\)|(rgb|hsl)\(\d{1,3}%?(,\s?\d{1,3}%?){2}\))/ig;
   if (regexColor.test(value) || regx.test(value)) {
     return value;


### PR DESCRIPTION
Fixes #2 and adds a unit test for parsing an array of objects.

Fixes parsing of single item lists: sass needs a comma at the end to know that they are lists.

Improved regex detecting whether string is a number...though this is still fairly weak. Lacks inches, other units. Maybe worth looking into using [units](https://www.npmjs.com/package/units-css) or something similar.