### PR TITLE
Direct users to new webpack loader package

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ json2scss.convertJs([1, 2, 3]); // (1, 2, 3)
 
 _For more, please refer to the [View Demo](https://codesandbox.io/s/json2scss-map-demo-phcsf?file=/theme/output.scss)_
 
-Alternatively, If you're using custom Webpack Configuration, you can use this tool to easily import JSON files and get the correct values.
-[Json2scss-map-webpack-importer](https://www.npmjs.com/package/json2scss-map-webpack-importer)
+Alternatively, If you're using a custom Webpack Configuration, you can use this tool to easily import JSON or javascript files and get the correct values.
+[@strawburster/sass-json-loader](https://codeberg.org/strawburster/-/packages/npm/@strawburster%2Fsass-json-loader)
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 


### PR DESCRIPTION
Thank you for mentioning my npm package! Unfortunately, it seems the sass compiler API is not very consistent between implementations, and the json2scss-map-webpack-importer only works with the deprecated node-sass package.

Instead of adding compatibility with the newer compiler, I decided to side-step it by defining a separate webpack loader that will call json2scss-map before the sass-loader even sees anything.

This should allow the new package to be compiler-agnostic, and only depend on the webpack loader API, which hasn't changed ever as far as I know, and this package's API.